### PR TITLE
overhaul matchmaking system

### DIFF
--- a/rocket_learn/agent/types.py
+++ b/rocket_learn/agent/types.py
@@ -1,0 +1,13 @@
+from typing import TypedDict, Dict, Optional
+
+from rocket_learn.agent.pretrained_policy import HardcodedAgent
+
+
+class PretrainedAgent(TypedDict):
+    prob: float  # Probability agent appears in training
+    eval: bool  # Whether or not to include in eval pools
+    p_deterministic_training: float  # Probability of using deterministic in training
+    key: str  # The key to be used for the redis hash set, should be unique
+
+
+PretrainedAgents = Dict[HardcodedAgent, PretrainedAgent]

--- a/rocket_learn/matchmaker/base_matchmaker.py
+++ b/rocket_learn/matchmaker/base_matchmaker.py
@@ -18,6 +18,6 @@ class BaseMatchmaker(ABC):
         :param n_agents: The number of agents to appear in the match.
         :param evaluate: A boolean representing whether or not the matchup generated is for an evaluation match.
 
-        :return: A tuple with 2 parallel lists and a bool. The first is a list of version names, the second is a list of ratings, the third is whether or not the match is an evaluation match.
+        :return: A tuple with 2 parallel lists and a bool. The first is a list of version names, the second is a list of ratings, the third is whether or not the match is an evaluation match. -1 in version name means latest.
         """
         raise NotImplementedError

--- a/rocket_learn/matchmaker/base_matchmaker.py
+++ b/rocket_learn/matchmaker/base_matchmaker.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Union
+
+from trueskill import Rating
+from redis import Redis
+
+from rocket_learn.agent.types import PretrainedAgents
+
+
+class BaseMatchmaker(ABC):
+    @abstractmethod
+    def generate_matchup(self, redis: Redis, n_agents: int, evaluate: bool) -> Tuple[List[Union[str, int]], List[Rating], bool]:
+        """
+        Function to compute the reward for a player. This function is given a player argument, and it is expected that
+        the reward returned by this function will be for that player.
+
+        :param redis: The Redis client that hosts the ratings database and latest model
+        :param n_agents: The number of agents to appear in the match.
+        :param evaluate: A boolean representing whether or not the matchup generated is for an evaluation match.
+
+        :return: A tuple with 2 parallel lists and a bool. The first is a list of version names, the second is a list of ratings, the third is whether or not the match is an evaluation match.
+        """
+        raise NotImplementedError

--- a/rocket_learn/matchmaker/matchmaker.py
+++ b/rocket_learn/matchmaker/matchmaker.py
@@ -69,7 +69,8 @@ class Matchmaker(BaseMatchmaker):
         latest_key = f"{latest_id}-stochastic"
 
         # This is the version of the most recent model (NOT just eval models)
-        latest_version = int(redis.get(VERSION_LATEST))
+        # Doing this instead of int(redis.get(VERSION_LATEST)) because the latest model is whatever is currently in rollout worker
+        latest_version = -1
 
         # This is a training match with all latest agents, no further logic necessary
         if not evaluate and n_non_latest == 0:

--- a/rocket_learn/matchmaker/matchmaker.py
+++ b/rocket_learn/matchmaker/matchmaker.py
@@ -1,0 +1,257 @@
+import numpy as np
+import itertools
+
+from rocket_learn.matchmaker.base_matchmaker import BaseMatchmaker
+from rocket_learn.rollout_generator.redis.utils import get_rating, get_ratings, get_pretrained_ratings, LATEST_RATING_ID, VERSION_LATEST
+from rocket_learn.utils.util import probability_NvsM
+from rocket_learn.agent.types import PretrainedAgents
+
+
+class Matchmaker(BaseMatchmaker):
+
+    def __init__(self, sigma_target=1, pretrained_agents: PretrainedAgents = None, non_latest_version_prob=[1, 0, 0, 0],
+                 past_version_prob=1, full_team_trainings=0, full_team_evaluations=0, force_non_latest_orange=False):
+        """
+        :param sigma_target: The sigma value at which agents stop playing in eval matches frequently
+        :param pretrained_agents: a configuration dict for how and how often to use pretrained agents in matchups.
+        :param non_latest_version_prob: An array such that the ith index is the probability that i agents in a training matchup are not the latest version of the model.
+        :param past_version_prob: The probability that a non-latest agent in the matchup is a past version of the model.
+        :param full_team_trainings: The probability that a match uses all agents of the same type on a given team in training.
+        :param full_team_evaluations: The probability that a match uses all agents of the same type on a given team in evals.
+        :param force_non_latest_orange: A boolean that, if true, ensures the first player in the list is latest agent (if one exists in the match).
+        """
+        self.sigma_target = sigma_target
+        self.non_latest_version_prob = np.array(
+            non_latest_version_prob) / sum(non_latest_version_prob)
+        self.past_version_prob = 1 if pretrained_agents is None else past_version_prob
+        self.full_team_trainings = full_team_trainings
+        self.full_team_evaluations = full_team_evaluations
+        self.force_non_latest_orange = force_non_latest_orange
+        pretrained_agents_keys, pretrained_agents_values = zip(
+            *pretrained_agents.items())
+        self.pretrained_agents = pretrained_agents_keys
+        pretrained_probs = [p["prob"] for p in pretrained_agents_values]
+        self.pretrained_probs = np.array(
+            pretrained_probs) / sum(pretrained_probs)
+        self.pretrained_evals = [p["eval"] for p in pretrained_agents_values]
+        self.pretrained_p_deterministic_training = [
+            p["p_deterministic_training"] for p in pretrained_agents_values]
+        self.pretrained_keys = [p["key"] for p in pretrained_agents_values]
+        self.pretrained_eval_keys = [k for i, k in enumerate(
+            self.pretrained_keys) if self.pretrained_evals[i]]
+
+    def generate_matchup(self, redis, n_agents, evaluate):
+        full_team_match = np.random.random() < (
+            self.full_team_evaluations if evaluate else self.full_team_trainings)
+        if full_team_match:
+            n_picks = 2
+        else:
+            n_picks = n_agents
+        if not evaluate:
+            n_non_latest = np.random.choice(
+                len(self.non_latest_version_prob), p=self.non_latest_version_prob)
+            if full_team_match:
+                # We make either one or zero non-latest pick
+                n_non_latest = int(n_non_latest > 0)
+            else:
+                # We only want a maximum of half the agents to be non latest in training matchups
+                n_non_latest = min(n_agents // 2, n_non_latest)
+            n_past_version = np.random.binomial(
+                n_non_latest, self.past_version_prob)
+            n_each_pretrained = np.random.multinomial(
+                n_non_latest-n_past_version, self.pretrained_probs)
+            n_picks -= n_non_latest - n_past_version
+
+        per_team = n_agents // 2
+        gamemode = f"{per_team}v{per_team}"
+        gamemode = '1v0' if gamemode == '0v0' else gamemode
+        latest_id = redis.get(LATEST_RATING_ID).decode("utf-8")
+        latest_key = f"{latest_id}-stochastic"
+
+        # This is the version of the most recent model (NOT just eval models)
+        latest_version = int(redis.get(VERSION_LATEST))
+
+        # This is a training match with all latest agents, no further logic necessary
+        if not evaluate and n_non_latest == 0:
+            rating = get_rating(gamemode, latest_key, redis)
+            return [latest_version] * n_agents, [rating] * n_agents, False
+
+        past_version_ratings = get_ratings(gamemode, redis)
+        # This is the rating of the most recent eval model
+        latest_rating = past_version_ratings[latest_key]
+        past_version_ratings_keys, past_version_ratings_values = zip(
+            *past_version_ratings.items())
+
+        # We also have the pretrained agents' ratings (the ones that have eval set to true, that is)
+        pretrained_ratings = get_pretrained_ratings(gamemode, redis)
+        pretrained_ratings_keys, pretrained_ratings_values = zip(
+            *[p for p in pretrained_ratings.items() if "-".join(p[0].split("-")[:-1]) in self.pretrained_eval_keys])
+
+        all_ratings_keys = past_version_ratings_keys + pretrained_ratings_keys
+        all_ratings_values = past_version_ratings_values + pretrained_ratings_values
+
+        if evaluate and len(all_ratings_keys) < n_picks:
+            # Can't run evaluation game, not enough agents
+            return [latest_version] * n_agents, [latest_rating] * n_agents, False
+
+        if evaluate:  # Evaluation game, try to find agents with high sigma
+            sigmas = np.array(
+                [r.sigma for r in all_ratings_values])
+            probs = np.clip(sigmas - self.sigma_target, a_min=0, a_max=None)
+            s = probs.sum()
+            if s == 0:  # No versions with high sigma available
+                if np.random.normal(0, self.sigma_target) > 1:
+                    # Some chance of doing a match with random versions, so they might correct themselves
+                    probs = np.ones_like(probs) / len(probs)
+                else:
+                    return [latest_version] * n_agents, [latest_rating] * n_agents, False
+            else:
+                probs /= s
+            chosen_first_idx = np.random.choice(len(probs), p=probs)
+            chosen_first_key = all_ratings_keys[chosen_first_idx]
+            chosen_first_rating = all_ratings_values[chosen_first_idx]
+        else:
+            chosen_first_key = latest_version
+            chosen_first_rating = latest_rating
+
+        if full_team_match:
+            versions = [chosen_first_key] * per_team
+            ratings = [chosen_first_rating] * per_team
+        else:
+            versions = [chosen_first_key]
+            ratings = [chosen_first_rating]
+
+        n_picks -= 1
+
+        if not evaluate:
+            # In a training match, we also need to add in the pretrained agents we have already decided upon
+            has_pretrained = n_non_latest - n_past_version > 0
+            if full_team_match and has_pretrained:
+                pretrained_idx = list(n_each_pretrained).index(1)
+                use_deterministic = np.random.random(
+                ) < self.pretrained_p_deterministic_training[pretrained_idx]
+                pretrained_key = self.pretrained_keys[pretrained_idx] + (
+                    "-deterministic" if use_deterministic else "-stochastic")
+                versions += [pretrained_key] * per_team
+                ratings += [pretrained_ratings_values[pretrained_ratings_keys.index(
+                    pretrained_key)]] * per_team
+                if self.force_non_latest_orange or np.random.random() < 0.5:
+                    return versions, ratings, False
+                else:
+                    mid = len(versions) // 2
+                    return (versions[mid:] + versions[:mid]), (ratings[mid:] + ratings[:mid]), False
+            elif has_pretrained:
+                for i, n_agent in enumerate(n_each_pretrained):
+                    n_deterministic = np.random.binomial(
+                        n_agent, self.pretrained_p_deterministic_training[i])
+                    versions += [self.pretrained_keys[i] +
+                                 "-deterministic"] * n_deterministic
+                    versions += [self.pretrained_keys[i] +
+                                 "-stochastic"] * (n_agent - n_deterministic)
+                    ratings += [pretrained_ratings_values[pretrained_ratings_keys.index(
+                        self.pretrained_keys[i] + "-deterministic")]] * n_deterministic
+                    ratings += [pretrained_ratings_values[pretrained_ratings_keys.index(
+                        self.pretrained_keys[i] + "-stochastic")]] * (n_agent - n_deterministic)
+
+            # and the number of agents that are latest. If full_team_match is true then at this point in execution we must have n_past_version == 1 so there is nothing to add
+            if not full_team_match:
+                versions += [latest_version] * (n_agents - n_non_latest - 1)
+                ratings += [latest_rating] * (n_agents - n_non_latest - 1)
+
+        # At this point in execution, ratings contains all the information necessary to randomly fill the remaining spots with players via matchmaking pool.
+        # If evaluate, this pool includes pretrained. If not, this pool is only past versions.
+
+        ratings_values_pool = all_ratings_values if evaluate else past_version_ratings_values
+        ratings_keys_pool = all_ratings_keys if evaluate else past_version_ratings_keys
+        probs = np.zeros(len(ratings_values_pool))
+
+        # We need to calculate the nvn win prob against the chosen_first agent for everyone in the pool. In evaluation matches where full_team_match is true,
+        # we don't want to have our remaining pick be the same agent as chosen_first.
+        for i, rating in enumerate(ratings_values_pool):
+            if evaluate and full_team_match and i == versions[0]:
+                p = 0
+            else:
+                p = probability_NvsM(
+                    [rating] * per_team, [ratings[0]] * per_team)
+            probs[i] = p * (1 - p)
+
+        probs /= probs.sum()
+
+        if full_team_match:
+            chosen_idx = np.random.choice(len(probs), p=probs)
+            versions += [ratings_keys_pool[chosen_idx]] * per_team
+            ratings += [ratings_values_pool[chosen_idx]] * per_team
+            if self.force_non_latest_orange or np.random.random() < 0.5:
+                return versions, ratings, evaluate
+            else:
+                mid = len(versions) // 2
+                return (versions[mid:] + versions[:mid]), (ratings[mid:] + ratings[:mid]), evaluate
+        else:
+            chosen_idxs = np.random.choice(len(probs), size=n_picks, p=probs)
+            for chosen_idx in chosen_idxs:
+                versions += [ratings_keys_pool[chosen_idx]]
+                ratings += [ratings_values_pool[chosen_idx]]
+
+            # We now have all the versions and ratings that will be used in parallel lists. Now weight all permutations of matches by fairness and pick one
+            matchups = []
+            qualities = []
+            for team1 in itertools.combinations(range(n_agents), per_team):
+                team2 = [idx for idx in range(n_agents) if idx not in team1]
+                team1_ratings_keys = [versions[v] for v in team1]
+                team1_ratings_values = [ratings[v] for v in team1]
+                team2_ratings_keys = [versions[v] for v in team2]
+                team2_ratings_values = [ratings[v] for v in team2]
+                # Don't want team against team in evals
+                ratings_keys_n_each = [{}, {}]
+                for i, ratings_keys in enumerate([team1_ratings_keys, team2_ratings_keys]):
+                    for key in ratings_keys:
+                        if key not in ratings_keys_n_each[i]:
+                            ratings_keys_n_each[i][key] = 1
+                        else:
+                            ratings_keys_n_each[i][key] += 1
+                same = True
+                for ratings_key, ratings_n in ratings_keys_n_each[0].items():
+                    if ratings_key not in ratings_keys_n_each[1] or ratings_n != ratings_keys_n_each[1][ratings_key]:
+                        same = False
+                        break
+                if same:
+                    p = 0
+                else:
+                    p = probability_NvsM(
+                        team1_ratings_values, team2_ratings_values)
+                matchups.append(list(team1))
+                qualities.append(p * (1 - p))
+            qualities = np.array(qualities)
+            s = qualities.sum()
+            if s == 0:
+                # Bad luck, just do regular match
+                return [latest_version] * n_agents, [latest_rating] * n_agents, False
+
+            # Pick a matchup, randomize ordering within team, and reorder versions and ratings accordingly
+            # Due to the way combinations works, randomizing which team team1 is on (orange or blue) doesn't change anything
+            matchup_idx = np.random.choice(len(matchups), p=qualities / s)
+            team1 = matchups[matchup_idx]
+            team2 = [idx for idx in range(n_agents) if idx not in team1]
+            np.random.shuffle(team1)
+            np.random.shuffle(team2)
+            if self.force_non_latest_orange and latest_version in versions:
+                latest_version_idx = versions.index(latest_version)
+                if latest_version_idx in team1:
+                    blue_team = team1
+                    orange_team = team2
+                else:
+                    blue_team = team2
+                    orange_team = team1
+                # Swap the latest version car to be in position 0
+                temp_idx = blue_team.index(latest_version_idx)
+                temp = blue_team[temp_idx]
+                blue_team[temp_idx] = blue_team[0]
+                blue_team[0] = temp
+                team1 = blue_team
+                team2 = orange_team
+
+            ordering = team1 + team2
+            versions = [versions[idx] for idx in ordering]
+            ratings = [ratings[idx] for idx in ordering]
+
+            return versions, ratings, evaluate

--- a/rocket_learn/rollout_generator/redis/redis_rollout_generator.py
+++ b/rocket_learn/rollout_generator/redis/redis_rollout_generator.py
@@ -367,16 +367,18 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
             commit=False
         )
 
-        pretrained_qualities = []
+        pretrained_qualities = {}
         for gamemode in self.gamemodes:
             qualities = get_pretrained_ratings(gamemode, self.redis)
+            pretrained_qualities[gamemode] = []
             for agent, rating in qualities.items():
-                pretrained_qualities.append(
-                    (agent + "-" + gamemode, rating.mu))
+                pretrained_qualities[gamemode].append(
+                    (agent, rating.mu))
 
-        self.logger.log({
-            "pretrained/qualities": wandb.Table(columns=["name", "rating"], data=pretrained_qualities)
-        })
+        for gamemode in pretrained_qualities:
+            self.logger.log({
+                f"pretrained/qualities-{gamemode}": wandb.Table(columns=["name", "rating"], data=pretrained_qualities[gamemode])
+            })
 
         if self.gamemodes[0] != '1v0':
             self._plot_ratings()

--- a/rocket_learn/rollout_generator/redis/redis_rollout_generator.py
+++ b/rocket_learn/rollout_generator/redis/redis_rollout_generator.py
@@ -14,11 +14,12 @@ from rlgym.utils import ObsBuilder, RewardFunction
 from rlgym.utils.action_parsers import ActionParser
 from trueskill import Rating, rate, SIGMA
 
+from rocket_learn.agent.types import PretrainedAgents
 from rocket_learn.experience_buffer import ExperienceBuffer
 from rocket_learn.rollout_generator.base_rollout_generator import BaseRolloutGenerator
-from rocket_learn.rollout_generator.redis.utils import decode_buffers, _unserialize, QUALITIES, _serialize, ROLLOUTS, \
-    VERSION_LATEST, OPPONENT_MODELS, CONTRIBUTORS, N_UPDATES, MODEL_LATEST, _serialize_model, get_rating, \
-    _ALL, LATEST_RATING_ID, EXPERIENCE_PER_MODE
+from rocket_learn.rollout_generator.redis.utils import decode_buffers, _unserialize, PRETRAINED_QUALITIES, QUALITIES, _serialize, ROLLOUTS, \
+    VERSION_LATEST, OPPONENT_MODELS, CONTRIBUTORS, N_UPDATES, MODEL_LATEST, _serialize_model, get_rating, get_ratings, \
+    get_pretrained_rating, get_pretrained_ratings, add_pretrained_ratings, _ALL, LATEST_RATING_ID, EXPERIENCE_PER_MODE
 from rocket_learn.utils.stat_trackers.stat_tracker import StatTracker
 
 
@@ -42,6 +43,7 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
             default_sigma=SIGMA,
             min_sigma=1,
             gamemodes=("1v1", "2v2", "3v3"),
+            pretrained_agents: PretrainedAgents = None,
             stat_trackers: Optional[List[StatTracker]] = None,
     ):
         self.lastsave_ts = None
@@ -50,9 +52,17 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
         self.redis = redis
         self.logger = logger
 
+        add_pretrained_ratings(
+            self.redis, pretrained_agents, gamemodes=gamemodes)
+        self.pretrained_agents_keys = []
+        if pretrained_agents is not None:
+            for config in pretrained_agents.values():
+                self.pretrained_agents_keys.append(config["key"])
+
         # TODO saving/loading
         if clear:
-            self.redis.delete(*(_ALL + tuple(QUALITIES.format(gm) for gm in gamemodes)))
+            self.redis.delete(*(_ALL + tuple(QUALITIES.format(gm)
+                              for gm in gamemodes)))
             self.redis.set(N_UPDATES, 0)
         else:
             if self.redis.exists(ROLLOUTS) > 0:
@@ -78,9 +88,11 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
 
     @staticmethod
     def _process_rollout(rollout_bytes, latest_version, obs_build_func, rew_build_func, act_build_func, max_age):
-        rollout_data, versions, uuid, name, result, has_obs, has_states, has_rewards = _unserialize(rollout_bytes)
+        rollout_data, versions, uuid, name, result, has_obs, has_states, has_rewards = _unserialize(
+            rollout_bytes)
 
-        v_check = [v for v in versions if isinstance(v, int) or v.startswith("-")]
+        v_check = [v for v in versions if isinstance(
+            v, int) or v.startswith("-")]
 
         if any(version < 0 and abs(version - latest_version) > max_age for version in v_check):
             return
@@ -96,46 +108,72 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
     def _update_ratings(self, name, versions, buffers, latest_version, result):
         ratings = []
         relevant_buffers = []
-        gamemode = f"{len(versions) // 2}v{len(versions) // 2}"  # TODO: support unfair games
+        # TODO: support unfair games
+        gamemode = f"{len(versions) // 2}v{len(versions) // 2}"
 
-        versions = [v for v in versions if v != "na"]
-        for version, buffer in itertools.zip_longest(versions, buffers):
+        has_buffer_versions = [
+            v for v in versions if isinstance(v, int) or (v != "human" and "-".join(v.split("-")[:-1]) not in self.pretrained_agents_keys)]
+        for version, buffer in itertools.zip_longest(has_buffer_versions, buffers):
             if isinstance(version, int) and version < 0:
                 if abs(version - latest_version) <= self.max_age:
                     relevant_buffers.append(buffer)
                     self.contributors[name] += buffer.size()
                 else:
                     return []
+
+        rated_versions = [v for v in versions if isinstance(
+            v, str) and v != "human"]
+        for version in rated_versions:
+            short_name = "-".join(version.split("-")[:-1])
+            if short_name in self.pretrained_agents_keys:
+                rating = get_pretrained_rating(
+                    gamemode, version, self.redis)
             else:
                 rating = get_rating(gamemode, version, self.redis)
-                ratings.append(rating)
+            ratings.append(rating)
 
         # Only old versions, calculate MMR
         if len(ratings) == len(versions) and len(buffers) == 0:
-            blue_players = sum(divmod(len(ratings), 2))
+            blue_players = len(versions) // 2
             blue = tuple(ratings[:blue_players])  # Tuple is important
             orange = tuple(ratings[blue_players:])
 
             # In ranks lowest number is best, result=-1 is orange win, 0 tie, 1 blue
-            r1, r2 = rate((blue, orange), ranks=(0, result))
+            try:
+                r1, r2 = rate((blue, orange), ranks=(0, result))
+            except:
+                print("what?")
 
             # Some trickery to handle same rating appearing multiple times, we just average their new mus and sigmas
             ratings_versions = {}
             for rating, version in zip(r1 + r2, versions):
                 ratings_versions.setdefault(version, []).append(rating)
 
-            mapping = {}
+            mapping_past = {}
+            mapping_pretrained = {}
             for version, ratings in ratings_versions.items():
                 # In case of duplicates, average ratings together (not strictly necessary with default setup)
                 # Also limit sigma to its lower bound
                 avg_rating = Rating(sum(r.mu for r in ratings) / len(ratings),
                                     max(sum(r.sigma ** 2 for r in ratings) ** 0.5 / len(ratings), self.min_sigma))
-                mapping[version] = _serialize(tuple(avg_rating))
-            gamemode = f"{len(versions) // 2}v{len(versions) // 2}"  # TODO: support unfair games
-            self.redis.hset(QUALITIES.format(gamemode), mapping=mapping)
+                short_name = "-".join(version.split("-")[:-1])
+                if short_name in self.pretrained_agents_keys:
+                    mapping_pretrained[version] = _serialize(tuple(avg_rating))
+                else:
+                    mapping_past[version] = _serialize(tuple(avg_rating))
+            # TODO: support unfair games
+            gamemode = f"{len(versions) // 2}v{len(versions) // 2}"
+
+            if mapping_past:
+                self.redis.hset(QUALITIES.format(
+                    gamemode), mapping=mapping_past)
+            if mapping_pretrained:
+                self.redis.hset(PRETRAINED_QUALITIES.format(gamemode),
+                                mapping=mapping_pretrained)
 
         if len(relevant_buffers) > 0:
-            self.redis.hincrby(EXPERIENCE_PER_MODE, gamemode, len(relevant_buffers) * relevant_buffers[0].size())
+            self.redis.hincrby(EXPERIENCE_PER_MODE, gamemode, len(
+                relevant_buffers) * relevant_buffers[0].size())
 
         return relevant_buffers
 
@@ -169,9 +207,11 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
                 buffers, states, versions, uuid, name, result = res
                 # versions = [version for version in versions if version != 'na']  # don't track humans or hardcoded
 
-                relevant_buffers = self._update_ratings(name, versions, buffers, latest_version, result)
+                relevant_buffers = self._update_ratings(
+                    name, versions, buffers, latest_version, result)
                 if len(relevant_buffers) > 0:
-                    self._update_stats(states, [b in relevant_buffers for b in buffers])
+                    self._update_stats(
+                        states, [b in relevant_buffers for b in buffers])
                 yield from relevant_buffers
 
     def _plot_ratings(self):
@@ -184,7 +224,7 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
             gamemodes.append(mean_key)
         for gamemode in gamemodes:
             if gamemode != mean_key:
-                ratings = get_rating(gamemode, None, self.redis)
+                ratings = get_ratings(gamemode, self.redis)
                 if len(ratings) <= 0:
                     return
             baseline = None
@@ -201,7 +241,8 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
                             mus.append(r.mu)
                             sigmas.append(r.sigma)
                             mean = means.setdefault(mode, {}).get(v, (0, 0))
-                            means[mode][v] = (mean[0] + r.mu, mean[1] + r.sigma ** 2)
+                            means[mode][v] = (
+                                mean[0] + r.mu, mean[1] + r.sigma ** 2)
                             # *Smoothly* transition from red, to green, to blue depending on gamemode
                     mid = (len(self.gamemodes) - 1) / 2
                     # avoid divide by 0 issues if there's only one gamemode, this moves it halfway into the colors
@@ -218,8 +259,10 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
                 else:
                     means_mode = means.get(mode, {})
                     x = list(means_mode.keys())
-                    mus = [mean[0] / len(self.gamemodes) for mean in means_mode.values()]
-                    sigmas = [(mean[1] / len(self.gamemodes)) ** 0.5 for mean in means_mode.values()]
+                    mus = [mean[0] / len(self.gamemodes)
+                           for mean in means_mode.values()]
+                    sigmas = [(mean[1] / len(self.gamemodes)) **
+                              0.5 for mean in means_mode.values()]
                     r = g = b = 1 / 3
 
                 indices = np.argsort(x)
@@ -228,7 +271,8 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
                 sigmas = np.array(sigmas)[indices]
 
                 if baseline is None:
-                    baseline = mus[0]  # Stochastic initialization is defined as the baseline (0 mu)
+                    # Stochastic initialization is defined as the baseline (0 mu)
+                    baseline = mus[0]
                 mus = mus - baseline
                 y = mus
                 y_upper = mus + 2 * sigmas  # 95% confidence
@@ -250,7 +294,8 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
                     ),
                     go.Scatter(
                         x=np.concatenate((x, x[::-1])),  # x, then x reversed
-                        y=np.concatenate((y_upper, y_lower[::-1])),  # upper, then lower reversed
+                        # upper, then lower reversed
+                        y=np.concatenate((y_upper, y_lower[::-1])),
                         fill='toself',
                         fillcolor=f'rgba({color},0.2)',
                         line=dict(color='rgba(255,255,255,0)'),
@@ -267,7 +312,8 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
             return
 
         fig = go.Figure(fig_data)
-        fig.update_layout(title="Rating", xaxis_title="Iteration", yaxis_title="TrueSkill")
+        fig.update_layout(
+            title="Rating", xaxis_title="Iteration", yaxis_title="TrueSkill")
 
         self.logger.log({
             "qualities": fig,
@@ -288,16 +334,19 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
 
         # Set quality
         for gamemode in self.gamemodes:
-            ratings = get_rating(gamemode, None, self.redis)
+            ratings = get_ratings(gamemode, self.redis)
 
             for mode in "stochastic", "deterministic":
                 if latest_id is not None:
                     latest_key = f"{latest_id}-{mode}"
-                    quality = Rating(ratings[latest_key].mu, self.default_sigma)
+                    quality = Rating(
+                        ratings[latest_key].mu, self.default_sigma)
                 else:
-                    quality = Rating(0, self.min_sigma)  # First (basically random) agent is initialized at 0
+                    # First (basically random) agent is initialized at 0
+                    quality = Rating(0, self.min_sigma)
 
-                self.redis.hset(QUALITIES.format(gamemode), f"{key}-{mode}", _serialize(tuple(quality)))
+                self.redis.hset(QUALITIES.format(gamemode),
+                                f"{key}-{mode}", _serialize(tuple(quality)))
 
         # Inform that new opponent is ready
         self.redis.set(LATEST_RATING_ID, key)
@@ -311,15 +360,29 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
         self.redis.set(MODEL_LATEST, model_bytes)
         self.redis.decr(VERSION_LATEST)
 
-        print("Top contributors:\n" + "\n".join(f"\t{c}: {n}" for c, n in self.contributors.most_common(5)))
+        print("Top contributors:\n" +
+              "\n".join(f"\t{c}: {n}" for c, n in self.contributors.most_common(5)))
         self.logger.log({
             "redis/contributors": wandb.Table(columns=["name", "steps"], data=self.contributors.most_common())},
             commit=False
         )
+
+        pretrained_qualities = []
+        for gamemode in self.gamemodes:
+            qualities = get_pretrained_ratings(gamemode, self.redis)
+            for agent, rating in qualities.items():
+                pretrained_qualities.append(
+                    (agent + "-" + gamemode, rating.mu))
+
+        self.logger.log({
+            "pretrained/qualities": wandb.Table(columns=["name", "rating"], data=pretrained_qualities)
+        })
+
         if self.gamemodes[0] != '1v0':
             self._plot_ratings()
         tot_contributors = self.redis.hgetall(CONTRIBUTORS)
-        tot_contributors = Counter({name: int(count) for name, count in tot_contributors.items()})
+        tot_contributors = Counter({name: int(count)
+                                   for name, count in tot_contributors.items()})
         tot_contributors += self.contributors
         if tot_contributors:
             self.redis.hset(CONTRIBUTORS, mapping=tot_contributors)
@@ -338,7 +401,8 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
         # save_freq = int(self.redis.get(SAVE_FREQ))
 
         if n_updates > 0:
-            self.logger.log({f"stat/{name}": value for name, value in self._get_stats().items()}, commit=False)
+            self.logger.log({f"stat/{name}": value for name,
+                            value in self._get_stats().items()}, commit=False)
         self._reset_stats()
 
         if n_updates % self.model_freq == 0:

--- a/rocket_learn/rollout_generator/redis/utils.py
+++ b/rocket_learn/rollout_generator/redis/utils.py
@@ -6,14 +6,16 @@ from typing import List, Optional, Union, Dict
 import numpy as np
 from redis import Redis
 from rlgym.utils.gamestates import GameState
-from trueskill import Rating
+from trueskill import Rating, SIGMA
 
+from rocket_learn.agent.types import PretrainedAgents
 from rocket_learn.experience_buffer import ExperienceBuffer
 from rocket_learn.utils.batched_obs_builder import BatchedObsBuilder
 from rocket_learn.utils.gamestate_encoding import encode_gamestate
 import msgpack
 import msgpack_numpy as m
 
+PRETRAINED_QUALITIES = "pretrained-qualities-{}"
 QUALITIES = "qualities-{}"
 N_UPDATES = "num-updates"
 # SAVE_FREQ = "save-freq"
@@ -59,28 +61,87 @@ def _unserialize_model(buf):
     return agent
 
 
-def get_rating(gamemode: str, model_id: Optional[str], redis: Redis) -> Union[Rating, Dict[str, Rating]]:
+def get_pretrained_ratings(gamemode: str, redis: Redis) -> Dict[str, Rating]:
     """
-    Get the rating of a player.
+    Get the ratings of all pretrained agents.
+    :param gamemode: The game mode to get the rating for.
+    :param redis: The redis client.
+    :return: The ratings as a dict.
+    """
+    quality_key = PRETRAINED_QUALITIES.format(gamemode)
+    return {
+        k.decode("utf-8"): Rating(*_unserialize(v))
+        for k, v in redis.hgetall(quality_key).items()
+    }
+
+
+def get_ratings(gamemode: str, redis: Redis) -> Dict[str, Rating]:
+    """
+    Get the ratings of all past versions of the agent.
+    :param gamemode: The game mode to get the rating for.
+    :param redis: The redis client.
+    :return: The ratings as a dict.
+    """
+    quality_key = QUALITIES.format(gamemode)
+    return {
+        k.decode("utf-8"): Rating(*_unserialize(v))
+        for k, v in redis.hgetall(quality_key).items()
+    }
+
+
+def get_pretrained_rating(gamemode: str, model_id: str, redis: Redis) -> Rating:
+    """
+    Get the rating of a past version of the agent.
     :param gamemode: The game mode to get the rating for.
     :param model_id: The id of the model.
     :param redis: The redis client.
-    :return: The rating of the player.
+    :return: The rating.
+    """
+    quality_key = PRETRAINED_QUALITIES.format(gamemode)
+    return Rating(*_unserialize(redis.hget(quality_key, model_id)))
+
+
+def get_rating(gamemode: str, model_id: str, redis: Redis) -> Rating:
+    """
+    Get the rating of a past version of the agent.
+    :param gamemode: The game mode to get the rating for.
+    :param model_id: The id of the model.
+    :param redis: The redis client.
+    :return: The rating.
     """
     quality_key = QUALITIES.format(gamemode)
-    if model_id is None:  # Return all ratings
-        return {
-            k.decode("utf-8"): Rating(*_unserialize(v))
-            for k, v in redis.hgetall(quality_key).items()
-        }
     return Rating(*_unserialize(redis.hget(quality_key, model_id)))
+
+
+def add_pretrained_ratings(redis: Redis, pretrained_agents: PretrainedAgents, gamemodes=("1v1", "2v2", "3v3"), starting_rating=0, starting_sigma=SIGMA, override=False):
+    """
+    Add pretrained agents to redis.
+    :param redis: The redis client.
+    :param pretrained_agents: The pretrained agents config.
+    :param gamemodes: The gamemodes for which to add the pretrained agents.
+    :param starting_rating: The rating for the agents to start with.
+    :param starting_sigma: The sigma for the agents to start with.
+    :param override: If true, will overwrite any matching existing agent keys with the new rating.
+    """
+    for config in pretrained_agents.values():
+        if config["eval"]:
+            for gamemode in gamemodes:
+                qualities = {
+                    k.decode("utf-8"): Rating(*_unserialize(v))
+                    for k, v in redis.hgetall(PRETRAINED_QUALITIES.format(gamemode)).items()
+                }
+                for mode in "stochastic", "deterministic":
+                    if override or f"{config['key']}-{mode}" not in qualities:
+                        redis.hset(PRETRAINED_QUALITIES.format(
+                            gamemode), f"{config['key']}-{mode}", _serialize(tuple(Rating(starting_rating, starting_sigma))))
 
 
 def encode_buffers(buffers: List[ExperienceBuffer], return_obs=True, return_states=True, return_rewards=True):
     res = []
 
     if return_states:
-        states = np.asarray([encode_gamestate(info["state"]) for info in buffers[0].infos] if len(buffers) > 0 else [])
+        states = np.asarray([encode_gamestate(info["state"])
+                            for info in buffers[0].infos] if len(buffers) > 0 else [])
         res.append(states)
 
     if return_obs:
@@ -103,7 +164,8 @@ def decode_buffers(enc_buffers, versions, has_obs, has_states, has_rewards,
                    obs_build_factory=None, rew_func_factory=None, act_parse_factory=None):
     assert has_states or has_obs, "Must have at least one of obs or states"
     assert has_states or has_rewards, "Must have at least one of rewards or states"
-    assert not has_obs or has_obs and has_rewards, "Must have both obs and rewards"  # TODO obs+no reward?
+    # TODO obs+no reward?
+    assert not has_obs or has_obs and has_rewards, "Must have both obs and rewards"
 
     i = 0
     if has_states:
@@ -142,7 +204,8 @@ def decode_buffers(enc_buffers, versions, has_obs, has_states, has_rewards,
             obs = obs_builder.batched_build_obs(game_states[:-1])
             prev_actions = act_parser.parse_actions(actions.reshape((-1,) + actions.shape[2:]).copy(), None).reshape(
                 actions.shape[:2] + (8,))
-            prev_actions = np.concatenate((np.zeros((actions.shape[0], 1, 8)), prev_actions[:, :-1]), axis=1)
+            prev_actions = np.concatenate(
+                (np.zeros((actions.shape[0], 1, 8)), prev_actions[:, :-1]), axis=1)
             obs_builder.add_actions(obs, prev_actions)
             buffers = [
                 ExperienceBuffer(observations=[obs[i]], actions=actions[i], rewards=rewards[i], dones=dones[i],
@@ -162,7 +225,8 @@ def decode_buffers(enc_buffers, versions, has_obs, has_states, has_rewards,
             ]
 
             env_actions = [
-                act_parser.parse_actions(actions[:, s, :].copy(), game_states[s])
+                act_parser.parse_actions(
+                    actions[:, s, :].copy(), game_states[s])
                 for s in range(actions.shape[1])
             ]
 
@@ -184,12 +248,15 @@ def decode_buffers(enc_buffers, versions, has_obs, has_states, has_rewards,
                     obs = obs_builder.build_obs(player, gs, env_actions[s][i])
                     if rewards is None:
                         if final:
-                            rew = rew_func.get_final_reward(player, gs, env_actions[s][i])
+                            rew = rew_func.get_final_reward(
+                                player, gs, env_actions[s][i])
                         else:
-                            rew = rew_func.get_reward(player, gs, env_actions[s][i])
+                            rew = rew_func.get_reward(
+                                player, gs, env_actions[s][i])
                     else:
                         rew = rewards[i][s]
-                    buffers[i].add_step(old_obs[i], actions[i][s], rew, final, log_probs[i][s], {"state": gs})
+                    buffers[i].add_step(
+                        old_obs[i], actions[i][s], rew, final, log_probs[i][s], {"state": gs})
                     obss.append(obs)
                 i += 1
 

--- a/rocket_learn/utils/generate_episode.py
+++ b/rocket_learn/utils/generate_episode.py
@@ -4,8 +4,10 @@ import numpy as np
 import torch
 from rlgym.gym import Gym
 from rlgym_sim.utils.reward_functions.common_rewards import ConstantReward
-from rlgym.utils.state_setters import DefaultState, StateWrapper
+from rlgym.utils.state_setters import DefaultState
 from rlgym.utils.terminal_conditions.common_conditions import GoalScoredCondition
+from tqdm import tqdm
+
 
 from rocket_learn.agent.policy import Policy
 from rocket_learn.agent.pretrained_policy import HardcodedAgent
@@ -13,12 +15,18 @@ from rocket_learn.experience_buffer import ExperienceBuffer
 from rocket_learn.utils.dynamic_gamemode_setter import DynamicGMSetter
 
 
-def generate_episode(env: Gym, policies, eval_setter=DefaultState(), evaluate=False, scoreboard=None, selector_skip_k=None,
+def generate_episode(env: Gym, policies, eval_setter=DefaultState(), evaluate=False, scoreboard=None, progress=False, selector_skip_k=None,
                      force_selector_choice=None) -> Tuple[List[ExperienceBuffer], int]:
     """
     create experience buffer data by interacting with the environment(s)
     """
-    if evaluate:  # Change setup temporarily to play a normal game (approximately)
+    if progress:
+        progress = tqdm(unit=" steps")
+    else:
+        progress = None
+
+    # Change setup temporarily to play a normal game (approximately)
+    if evaluate:
         # tools is an optional dependency
         from rlgym_tools.extra_terminals.game_condition import GameCondition
         terminals = env._match._terminal_conditions  # noqa
@@ -55,6 +63,7 @@ def generate_episode(env: Gym, policies, eval_setter=DefaultState(), evaluate=Fa
         for _ in range(sum(latest_policy_indices))
     ]
 
+    b = o = 0
     with torch.no_grad():
         tick = [0] * len(policies)
         do_selector = [True] * len(policies)
@@ -183,8 +192,21 @@ def generate_episode(env: Gym, policies, eval_setter=DefaultState(), evaluate=Fa
                 for exp_buf, obs, act, rew, log_prob in zip(rollouts, old_obs, all_indices, rewards, all_log_probs):
                     exp_buf.add_step(obs, act, rew, done, log_prob, info)
 
+            if progress is not None:
+                progress.update()
+                igt = progress.n * env._match._tick_skip / 120  # noqa
+                prog_str = f"{igt // 60:02.0f}:{igt % 60:02.0f} IGT"
+                if evaluate:
+                    prog_str += f", BLUE {b} - {o} ORANGE"
+                progress.set_postfix_str(prog_str)
+
             if done:
                 result += info["result"]
+                if info["result"] > 0:
+                    b += 1
+                elif info["result"] < 0:
+                    o += 1
+
                 if not evaluate:
                     break
                 elif game_condition.done:  # noqa
@@ -196,6 +218,9 @@ def generate_episode(env: Gym, policies, eval_setter=DefaultState(), evaluate=Fa
 
     if scoreboard is not None:
         scoreboard.random_resets = random_resets  # noqa Checked above
+
+    if progress is not None:
+        progress.close()
 
     if evaluate:
         if isinstance(env._match._state_setter, DynamicGMSetter):  # noqa

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,14 @@ Learning!
 """
 
 setup(
-   name='rocket_learn',
-   version='0.2.5',
-   description='Rocket Learn',
-   author=['Rolv Arild', 'Daniel Downs'],
-   url='https://github.com/Rolv-Arild/rocket-learn',
-   packages=[package for package in find_packages() if package.startswith("rocket_learn")],
-   long_description=long_description,
-   install_requires=['cloudpickle==1.6.0', 'gym', 'torch', 'tqdm', 'trueskill',
-                     'msgpack_numpy', 'wandb', 'pygame', 'keyboard'],
+    name='rocket_learn',
+    version='0.3.0',
+    description='Rocket Learn',
+    author=['Rolv Arild', 'Daniel Downs', 'Jonthan Keegan'],
+    url='https://github.com/Rolv-Arild/rocket-learn',
+    packages=[package for package in find_packages(
+    ) if package.startswith("rocket_learn")],
+    long_description=long_description,
+    install_requires=['cloudpickle==1.6.0', 'gym', 'torch', 'tqdm', 'trueskill',
+                      'msgpack_numpy', 'wandb', 'pygame', 'keyboard', 'tabulate'],
 )


### PR DESCRIPTION
breaking changes. rollout worker constructor takes a new Matchmaker parameter instead of past version prob, full team evaluations, etc. being passed into the rollout worker constructor directly. Matchmaker object has documentation for how it works.

pretrained_agents now is passed into Matchmaker, RedisRolloutWorker, and RedisRolloutGenerator. The format has some commented documentation in agent/types.